### PR TITLE
Add social icons to default footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -173,9 +173,9 @@ ga('send', 'pageview');
             <div class="col-md-6 col-sm-6 text-center text-lg-left">
                  Copyright © {{ site.time | date: "%Y" }} {{ site.name }} 
             </div>
-            <!--<div class="col-md-6 col-sm-6 text-center text-lg-right">    
-                <a target="_blank" href="https://www.wowthemes.net/mediumish-free-jekyll-template/">Mediumish Jekyll Theme</a> by WowThemes.net
-            </div>-->
+            <div class="col-md-6 col-sm-6 text-center text-lg-right">    
+                {% include share.html %}
+            </div>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
Hi! 

I added the social icons by rendering your [share partial](https://github.com/artofmarketingscience/artofmarketingscience.github.io/blob/master/_includes/share.html) for posts. 

Here's the original footer
![Screen Shot 2021-02-08 at 9 35 45 AM](https://user-images.githubusercontent.com/13026263/107227411-b9319000-69f1-11eb-9a43-707cde73da39.png)

and here's the new footer in this PR. You could try to build it with the standard `bundle exec jekyll serve` command

![Screen Shot 2021-02-08 at 9 16 07 AM](https://user-images.githubusercontent.com/13026263/107227448-c484bb80-69f1-11eb-8e70-4c218300a2bc.png)

Let me know what you think. Thanks!
